### PR TITLE
Removed use of magic numbers in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "express": "^4.17.1",
     "express-validator": "^6.11.1",
     "gravatar": "^1.8.1",
+    "http-status-codes": "^2.1.4",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^5.12.13",
     "prettier": "^2.3.1"

--- a/routes/api/__tests__/auth.js
+++ b/routes/api/__tests__/auth.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose')
 const request = require('supertest')
+const { StatusCodes } = require('http-status-codes')
 const server = require('../../../server')
 const User = require('../../../models/User')
 const { testAuth } = require('../../../config')
@@ -39,7 +40,7 @@ beforeAll(async () => {
 })
 describe('User login testing', () => {
   it('Should log an existing user in', async () => {
-    expect.assertions(2)
+    expect.assertions(2) // skipcq: JS-0074
 
     const res = await request(server)
       .post('/api/auth')
@@ -49,12 +50,12 @@ describe('User login testing', () => {
         password: 'testpass123'
       })
 
-    expect(res.statusCode).toEqual(200)
+    expect(res.statusCode).toEqual(StatusCodes.OK)
     expect(res.body).toHaveProperty('token')
   })
 
   it('Should not log a non-existing user in', async () => {
-    expect.assertions(3)
+    expect.assertions(3) // skipcq: JS-0074
 
     const res = await request(server)
       .post('/api/auth')
@@ -64,14 +65,14 @@ describe('User login testing', () => {
         password: 'fakepass123'
       })
 
-    expect(res.statusCode).toEqual(400)
+    expect(res.statusCode).toEqual(StatusCodes.BAD_REQUEST)
     expect(res.body).not.toHaveProperty('token')
     expect(res.body.errors[0][0].msg).toEqual('Invalid credentials')
   })
 
   describe('Password testing', () => {
     it('Should not log an existing user in with a wrong password', async () => {
-      expect.assertions(3)
+      expect.assertions(3) // skipcq: JS-0074
 
       const res = await request(server)
         .post('/api/auth')
@@ -81,13 +82,13 @@ describe('User login testing', () => {
           password: 'fakepass123'
         })
 
-      expect(res.statusCode).toEqual(400)
+      expect(res.statusCode).toEqual(StatusCodes.BAD_REQUEST)
       expect(res.body).not.toHaveProperty('token')
       expect(res.body.errors[0][0].msg).toEqual('Invalid credentials')
     })
 
     it('Should not log an existing user in without a password', async () => {
-      expect.assertions(5)
+      expect.assertions(5) // skipcq: JS-0074
 
       const res = await request(server)
         .post('/api/auth')
@@ -96,7 +97,7 @@ describe('User login testing', () => {
           email: 'testuser@gmail.com'
         })
 
-      expect(res.statusCode).toEqual(400)
+      expect(res.statusCode).toEqual(StatusCodes.BAD_REQUEST)
       expect(res.body).not.toHaveProperty('token')
       expect(res.body.errors[0].msg).toEqual('Password is required')
       expect(res.body.errors[0].param).toEqual('password')
@@ -106,7 +107,7 @@ describe('User login testing', () => {
 
   describe('Email testing', () => {
     it('Should not log an existing user in with an invalid email', async () => {
-      expect.assertions(5)
+      expect.assertions(5) // skipcq: JS-0074
 
       const res = await request(server)
         .post('/api/auth')
@@ -116,7 +117,7 @@ describe('User login testing', () => {
           password: 'testpass123'
         })
 
-      expect(res.statusCode).toEqual(400)
+      expect(res.statusCode).toEqual(StatusCodes.BAD_REQUEST)
       expect(res.body).not.toHaveProperty('token')
       expect(res.body.errors[0].msg).toEqual('Please include a valid email')
       expect(res.body.errors[0].param).toEqual('email')
@@ -124,7 +125,7 @@ describe('User login testing', () => {
     })
 
     it('Should not log an existing user in without an email', async () => {
-      expect.assertions(5)
+      expect.assertions(5) // skipcq: JS-0074
 
       const res = await request(server)
         .post('/api/auth')
@@ -133,7 +134,7 @@ describe('User login testing', () => {
           password: 'testpass123'
         })
 
-      expect(res.statusCode).toEqual(400)
+      expect(res.statusCode).toEqual(StatusCodes.BAD_REQUEST)
       expect(res.body).not.toHaveProperty('token')
       expect(res.body.errors[0].msg).toEqual('Please include a valid email')
       expect(res.body.errors[0].param).toEqual('email')

--- a/routes/api/__tests__/users.js
+++ b/routes/api/__tests__/users.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose')
 const request = require('supertest')
+const { StatusCodes } = require('http-status-codes')
 const server = require('../../../server')
 const User = require('../../../models/User')
 const { testUsers } = require('../../../config')
@@ -29,7 +30,7 @@ afterEach(async () => {
 
 describe('Registration testing', () => {
   it('Should create a test user', async () => {
-    expect.assertions(2)
+    expect.assertions(2) // skipcq: JS-0074
 
     const res = await request(server)
       .post('/api/users')
@@ -39,13 +40,13 @@ describe('Registration testing', () => {
         email: 'testuser@gmail.com',
         password: 'testpass123'
       })
-    expect(res.statusCode).toEqual(200)
+    expect(res.statusCode).toEqual(StatusCodes.OK)
     expect(res.body).toHaveProperty('token')
   })
 
   describe('Test name param', () => {
     it('Should not create a test user without a name', async () => {
-      expect.assertions(5)
+      expect.assertions(5) // skipcq: JS-0074
 
       const res = await request(server)
         .post('/api/users')
@@ -54,7 +55,7 @@ describe('Registration testing', () => {
           email: 'baduser@gmail.com',
           password: 'testpass123'
         })
-      expect(res.statusCode).toEqual(400)
+      expect(res.statusCode).toEqual(StatusCodes.BAD_REQUEST)
       expect(res.body).not.toHaveProperty('token')
       expect(res.body.errors[0].msg).toEqual('Name is required!')
       expect(res.body.errors[0].param).toEqual('name')
@@ -64,7 +65,7 @@ describe('Registration testing', () => {
 
   describe('Test email param', () => {
     it('Should not create a test user without an email', async () => {
-      expect.assertions(5)
+      expect.assertions(5) // skipcq: JS-0074
 
       const res = await request(server)
         .post('/api/users')
@@ -73,7 +74,7 @@ describe('Registration testing', () => {
           name: 'Bad User',
           password: 'testpass123'
         })
-      expect(res.statusCode).toEqual(400)
+      expect(res.statusCode).toEqual(StatusCodes.BAD_REQUEST)
       expect(res.body).not.toHaveProperty('token')
       expect(res.body.errors[0].msg).toEqual('Please include a valid email')
       expect(res.body.errors[0].param).toEqual('email')
@@ -81,7 +82,7 @@ describe('Registration testing', () => {
     })
 
     it('Should not create a test user with an invalid email', async () => {
-      expect.assertions(5)
+      expect.assertions(5) // skipcq: JS-0074
 
       const res = await request(server)
         .post('/api/users')
@@ -91,7 +92,7 @@ describe('Registration testing', () => {
           email: 'baduser',
           password: 'testpass123'
         })
-      expect(res.statusCode).toEqual(400)
+      expect(res.statusCode).toEqual(StatusCodes.BAD_REQUEST)
       expect(res.body).not.toHaveProperty('token')
       expect(res.body.errors[0].msg).toEqual('Please include a valid email')
       expect(res.body.errors[0].param).toEqual('email')
@@ -101,7 +102,7 @@ describe('Registration testing', () => {
 
   describe('Test password param', () => {
     it('Should not create a test user without a password', async () => {
-      expect.assertions(5)
+      expect.assertions(5) // skipcq: JS-0074
 
       const res = await request(server)
         .post('/api/users')
@@ -110,7 +111,7 @@ describe('Registration testing', () => {
           name: 'Bad User',
           email: 'baduser@gmail.com'
         })
-      expect(res.statusCode).toEqual(400)
+      expect(res.statusCode).toEqual(StatusCodes.BAD_REQUEST)
       expect(res.body).not.toHaveProperty('token')
       expect(res.body.errors[0].msg).toEqual(
         'Please enter a password with 6 or more characters'
@@ -120,7 +121,7 @@ describe('Registration testing', () => {
     })
 
     it('Should not create a test user with an invalid password', async () => {
-      expect.assertions(5)
+      expect.assertions(5) // skipcq: JS-0074
 
       const res = await request(server)
         .post('/api/users')
@@ -130,7 +131,7 @@ describe('Registration testing', () => {
           email: 'baduser@gmail.com',
           password: '1234'
         })
-      expect(res.statusCode).toEqual(400)
+      expect(res.statusCode).toEqual(StatusCodes.BAD_REQUEST)
       expect(res.body).not.toHaveProperty('token')
       expect(res.body.errors[0].msg).toEqual(
         'Please enter a password with 6 or more characters'
@@ -158,12 +159,12 @@ describe('Delete user testing', () => {
   })
 
   it('Should delete the test user', async () => {
-    expect.assertions(2)
+    expect.assertions(2) // skipcq: JS-0074
 
     const res = await request(server)
       .delete('/api/users')
       .set('x-auth-token', token)
-    expect(res.statusCode).toEqual(200)
+    expect(res.statusCode).toEqual(StatusCodes.OK)
     expect(res.body.msg).toEqual('User deleted')
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1807,6 +1807,11 @@ http-proxy-agent@^4.0.1:
     agent-base "6"
     debug "4"
 
+http-status-codes@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/http-status-codes/-/http-status-codes-2.1.4.tgz#453d99b4bd9424254c4f6a9a3a03715923052798"
+  integrity sha512-MZVIsLKGVOVE1KEnldppe6Ij+vmemMuApDfjhVSLzyYP+td0bREEYyAoIw9yFePoBXManCuBqmiNP5FqJS5Xkg==
+
 https-proxy-agent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"


### PR DESCRIPTION
Introduced http-status-codes package to provide constants for http status codes,
and added skipcq comments to ignore the rule for expect.assertions() lines since
this is self evident (and I do not consider this a magic number)

closes #14