### PR TITLE
Ignored destructure rule

### DIFF
--- a/routes/api/__tests__/users.js
+++ b/routes/api/__tests__/users.js
@@ -154,7 +154,7 @@ describe('Delete user testing', () => {
         password: 'testpass123'
       })
 
-    token = res.body.token
+    token = res.body.token // skipcq: JS-0243
   })
 
   it('Should delete the test user', async () => {


### PR DESCRIPTION
In this case it does not make sense to perform object destructuring, since the
variable has already been defined.

closes #16