### PR TITLE
Added remove profile to users route

### DIFF
--- a/routes/api/__tests__/users.js
+++ b/routes/api/__tests__/users.js
@@ -216,25 +216,27 @@ describe('Delete user testing', () => {
     expect.assertions(6) // skipcq: JS-0074
 
     // Send delete request
-    var {
-      statusCode,
-      body: { msg }
+    let {
+      statusCode: userStatusCode,
+      body: { msg: userMsg }
     } = await request(server).delete('/api/users').set('x-auth-token', token)
 
-    expect(statusCode).toEqual(StatusCodes.OK)
-    expect(msg).toEqual('User deleted')
+    expect(userStatusCode).toEqual(StatusCodes.OK)
+    expect(userMsg).toEqual('User deleted')
 
     // Assert profile has been deleted
-    var { statusCode, body } = await request(server).get('/api/profile')
+    let { statusCode: profileStatusCode, body } = await request(server).get(
+      '/api/profile'
+    )
 
-    expect(statusCode).toEqual(StatusCodes.OK)
+    expect(profileStatusCode).toEqual(StatusCodes.OK)
     expect(body).toEqual([])
 
     // Assert user has been deleted
-    var {
-      statusCode,
+    let {
+      statusCode: authStatusCode,
       body: {
-        errors: [{ msg }]
+        errors: [{ msg: authMsg }]
       }
     } = await request(server)
       .post('/api/auth')
@@ -244,8 +246,8 @@ describe('Delete user testing', () => {
         password: 'testpass123'
       })
 
-    expect(statusCode).toEqual(StatusCodes.BAD_REQUEST)
-    expect(msg).toEqual('Invalid credentials')
+    expect(authStatusCode).toEqual(StatusCodes.BAD_REQUEST)
+    expect(authMsg).toEqual('Invalid credentials')
   })
 
   /**
@@ -255,25 +257,25 @@ describe('Delete user testing', () => {
     expect.assertions(6) // skipcq: JS-0074
 
     // Send delete request
-    var {
-      statusCode,
+    let {
+      statusCode: userStatusCode,
       body: { msg }
     } = await request(server).delete('/api/users').set('x-auth-token', '')
 
-    expect(statusCode).toEqual(StatusCodes.UNAUTHORIZED)
+    expect(userStatusCode).toEqual(StatusCodes.UNAUTHORIZED)
     expect(msg).toEqual('No token, authorization denied')
 
     // Assert profile has not been deleted
-    var {
-      statusCode,
+    let {
+      statusCode: profileStatusCode,
       body: [{ name }]
     } = await request(server).get('/api/profile')
 
-    expect(statusCode).toEqual(StatusCodes.OK)
+    expect(profileStatusCode).toEqual(StatusCodes.OK)
     expect(name).toEqual('test name')
 
     // Assert user has not been deleted
-    var { statusCode, body } = await request(server)
+    let { statusCode: authStatusCode, body } = await request(server)
       .post('/api/auth')
       .set('Content-Type', 'application/json')
       .send({
@@ -281,7 +283,7 @@ describe('Delete user testing', () => {
         password: 'testpass123'
       })
 
-    expect(statusCode).toEqual(StatusCodes.OK)
+    expect(authStatusCode).toEqual(StatusCodes.OK)
     expect(body).toHaveProperty('token')
   })
 })

--- a/routes/api/__tests__/users.js
+++ b/routes/api/__tests__/users.js
@@ -216,7 +216,7 @@ describe('Delete user testing', () => {
     expect.assertions(6) // skipcq: JS-0074
 
     // Send delete request
-    let {
+    const {
       statusCode: userStatusCode,
       body: { msg: userMsg }
     } = await request(server).delete('/api/users').set('x-auth-token', token)
@@ -225,7 +225,7 @@ describe('Delete user testing', () => {
     expect(userMsg).toEqual('User deleted')
 
     // Assert profile has been deleted
-    let { statusCode: profileStatusCode, body } = await request(server).get(
+    const { statusCode: profileStatusCode, body } = await request(server).get(
       '/api/profile'
     )
 
@@ -233,7 +233,7 @@ describe('Delete user testing', () => {
     expect(body).toEqual([])
 
     // Assert user has been deleted
-    let {
+    const {
       statusCode: authStatusCode,
       body: {
         errors: [{ msg: authMsg }]
@@ -257,7 +257,7 @@ describe('Delete user testing', () => {
     expect.assertions(6) // skipcq: JS-0074
 
     // Send delete request
-    let {
+    const {
       statusCode: userStatusCode,
       body: { msg }
     } = await request(server).delete('/api/users').set('x-auth-token', '')
@@ -266,7 +266,7 @@ describe('Delete user testing', () => {
     expect(msg).toEqual('No token, authorization denied')
 
     // Assert profile has not been deleted
-    let {
+    const {
       statusCode: profileStatusCode,
       body: [{ name }]
     } = await request(server).get('/api/profile')
@@ -275,7 +275,7 @@ describe('Delete user testing', () => {
     expect(name).toEqual('test name')
 
     // Assert user has not been deleted
-    let { statusCode: authStatusCode, body } = await request(server)
+    const { statusCode: authStatusCode, body } = await request(server)
       .post('/api/auth')
       .set('Content-Type', 'application/json')
       .send({

--- a/routes/api/__tests__/users.js
+++ b/routes/api/__tests__/users.js
@@ -3,6 +3,7 @@ const request = require('supertest')
 const { StatusCodes } = require('http-status-codes')
 const server = require('../../../server')
 const User = require('../../../models/User')
+const Profile = require('../../../models/Profile')
 const { testUsers } = require('../../../config')
 
 /**
@@ -192,19 +193,95 @@ describe('Delete user testing', () => {
       })
 
     token = resToken
+
+    await request(server)
+      .post('/api/profile')
+      .set('Content-Type', 'application/json')
+      .set('x-auth-token', token)
+      .send({
+        name: 'test name',
+        bio: 'test bio',
+        location: 'test location'
+      })
+  })
+
+  afterEach(async () => {
+    await Profile.deleteMany()
   })
 
   /**
    * Tests the DELETE /api/users endpoint.
    */
   it('Should delete the test user', async () => {
-    expect.assertions(2) // skipcq: JS-0074
+    expect.assertions(6) // skipcq: JS-0074
 
-    const {
+    // Send delete request
+    var {
       statusCode,
       body: { msg }
     } = await request(server).delete('/api/users').set('x-auth-token', token)
+
     expect(statusCode).toEqual(StatusCodes.OK)
     expect(msg).toEqual('User deleted')
+
+    // Assert profile has been deleted
+    var { statusCode, body } = await request(server).get('/api/profile')
+
+    expect(statusCode).toEqual(StatusCodes.OK)
+    expect(body).toEqual([])
+
+    // Assert user has been deleted
+    var {
+      statusCode,
+      body: {
+        errors: [{ msg }]
+      }
+    } = await request(server)
+      .post('/api/auth')
+      .set('Content-Type', 'application/json')
+      .send({
+        email: 'testuser@gmail.com',
+        password: 'testpass123'
+      })
+
+    expect(statusCode).toEqual(StatusCodes.BAD_REQUEST)
+    expect(msg).toEqual('Invalid credentials')
+  })
+
+  /**
+   * Tests the DELETE /api/users endpoint.
+   */
+  it('Should not delete the user if given no token', async () => {
+    expect.assertions(6) // skipcq: JS-0074
+
+    // Send delete request
+    var {
+      statusCode,
+      body: { msg }
+    } = await request(server).delete('/api/users').set('x-auth-token', '')
+
+    expect(statusCode).toEqual(StatusCodes.UNAUTHORIZED)
+    expect(msg).toEqual('No token, authorization denied')
+
+    // Assert profile has not been deleted
+    var {
+      statusCode,
+      body: [{ name }]
+    } = await request(server).get('/api/profile')
+
+    expect(statusCode).toEqual(StatusCodes.OK)
+    expect(name).toEqual('test name')
+
+    // Assert user has not been deleted
+    var { statusCode, body } = await request(server)
+      .post('/api/auth')
+      .set('Content-Type', 'application/json')
+      .send({
+        email: 'testuser@gmail.com',
+        password: 'testpass123'
+      })
+
+    expect(statusCode).toEqual(StatusCodes.OK)
+    expect(body).toHaveProperty('token')
   })
 })

--- a/routes/api/users.js
+++ b/routes/api/users.js
@@ -6,6 +6,7 @@ const { check, validationResult } = require('express-validator')
 const jwt = require('jsonwebtoken')
 const auth = require('../../middleware/auth')
 const User = require('../../models/User')
+const Profile = require('../../models/Profile')
 const { jwtSecret, jwtExpiration } = require('../../config')
 
 const router = express.Router()
@@ -153,8 +154,8 @@ router.post(
  * @swagger
  * /api/users:
  *   delete:
- *     summary: Deletes a user TODO (and their profile)
- *     description: Deletes a user from the database TODO along with their profile.
+ *     summary: Deletes a user and their profile
+ *     description: Deletes a user from the database along with their profile.
  *     parameters:
  *       - in: header
  *         name: x-auth-token
@@ -180,7 +181,8 @@ router.post(
  */
 router.delete('/', auth, async (req, res) => {
   try {
-    // TODO: Remove profile
+    // Remove profile
+    await Profile.findOneAndRemove({ user: req.user.id })
 
     // Remove user
     await User.findOneAndRemove({ _id: req.user.id })


### PR DESCRIPTION
Added a call to Profile.findOneAndRemove(...) to the DELETE /api/users, ensuring
that profiles are deleted at the same time as accounts.
Also updated the tests to reflect this change.

closes #21