### PR TITLE
Removed typo left by autofix

### DIFF
--- a/start.js
+++ b/start.js
@@ -7,4 +7,4 @@ connectDB()
 
 const PORT = process.env.PORT || DEV_PORT
 
-app.listen(PORT, () => )
+app.listen(PORT)


### PR DESCRIPTION
DeepSource autofix bot left a typo in start.js by removing the console.log line
from a function. This function has now been removed and the code should run.

closes #46